### PR TITLE
feat: adds Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# MariaDB
+MYSQL_ROOT_PASSWORD=your_root_password_here
+MYSQL_DATABASE=solid
+MYSQL_USER=your_user_here
+MYSQL_PASSWORD=your_password_here
+
+# PHP
+PHP_IDE_CONFIG=serverName=solidarity

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # MariaDB
-MYSQL_ROOT_PASSWORD=your_root_password_here
+MYSQL_ROOT_PASSWORD=rootpass
 MYSQL_DATABASE=solid
-MYSQL_USER=your_user_here
-MYSQL_PASSWORD=your_password_here
+MYSQL_USER=solid
+MYSQL_PASSWORD=solidpass
 
 # PHP
 PHP_IDE_CONFIG=serverName=solidarity

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ composer.lock
 /data/pdf
 /data/phinx/phinx-local.php
 /public/assets/package-lock.json
+
+# Docker
+/db/data/
+.env
+*.env
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM php:8.3-fpm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    libzip-dev \
+    libxslt1-dev \
+    libgd-dev \
+    libbz2-dev \
+    librabbitmq-dev \
+    libssl-dev \
+    libmagickwand-dev \
+    unzip \
+    imagemagick \
+    default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN docker-php-ext-install \
+    bz2 \
+    gd \
+    intl \
+    mbstring \
+    opcache \
+    pdo_mysql \
+    soap \
+    xsl \
+    zip \
+    dom
+
+# Install Redis extension
+RUN pecl install redis igbinary \
+    && docker-php-ext-enable redis igbinary
+
+# Install ImageMagick extension
+RUN curl -sSLf \
+    -o /usr/local/bin/install-php-extensions \
+    https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
+    chmod +x /usr/local/bin/install-php-extensions && \
+    install-php-extensions imagick
+
+# Install Xdebug
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+# Configure PHP
+COPY docker/php/php.ini /usr/local/etc/php/conf.d/app.ini
+
+# Install composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html

--- a/README.docker.md
+++ b/README.docker.md
@@ -1,90 +1,90 @@
-# Docker Setup Instructions
+# Uputstva za Docker instalaciju
 
-## Prerequisites
+## Preduslovi
 
 - Docker
 - Docker Compose
 - Git
 
-## Setup Steps
+## Koraci za podešavanje
 
-1. Copy `.env.example` to `.env` and update the values:
+1. Kopirajte `.env.example` u `.env` i ažurirajte vrednosti:
 ```bash
 cp .env.example .env
-# Edit .env with your desired values
+# Izmenite .env sa željenim vrednostima
 ```
 
-2. Add these entries to your `/etc/hosts` file:
+2. Dodajte ove unose u vaš `/etc/hosts` fajl:
 ```
 127.0.0.1 solidarity.local
 127.0.0.1 solidforms.local
 ```
 
-2. Build and start the Docker containers:
+3. Izgradite i pokrenite Docker kontejnere:
 ```bash
 docker compose up -d
 ```
 
-The setup script will automatically:
-- Create the database
-- Install composer dependencies
-- Set up configuration files
-- Run database migrations
-- Create a test user
+Skripta za podešavanje će automatski:
+- Kreirati bazu podataka
+- Instalirati composer zavisnosti
+- Podesiti konfiguracione fajlove
+- Pokrenuti migracije baze podataka
+- Kreirati test korisnika
 
-## Services
+## Servisi
 
 - Backend: http://solidarity.local
 - Frontend: http://solidforms.local
-- Adminer (Database Management): http://localhost:8080
-  - System: MySQL
+- Adminer (Upravljanje bazom podataka): http://localhost:8080
+  - Sistem: MySQL
   - Server: mariadb
-  - Username: root
-  - Password: rootpass
-  - Database: solid
-- MailHog (Email Testing): http://localhost:8025
+  - Korisničko ime: root
+  - Lozinka: rootpass
+  - Baza podataka: solid
 - Redis: localhost:6379
+- Redis Insight (Redis upravljački interfejs): http://localhost:5540
 
-## Common Commands
+## Uobičajene komande
 
 ```bash
-# Start containers
+# Pokretanje kontejnera
 docker compose up -d
 
-# Stop containers
+# Zaustavljanje kontejnera
 docker compose down
 
-# View logs
+# Pregled logova
 docker compose logs -f
 
-# Rebuild containers
+# Ponovno građenje kontejnera
 docker compose up -d --build
 
-# Access PHP container
+# Pristup PHP kontejneru
 docker compose exec php bash
 
-# Run composer commands
+# Pokretanje composer komandi
 docker compose exec php composer install
 
-# Run database migrations
+# Pokretanje migracija baze podataka
 docker compose exec php php bin/doctrine orm:schema-tool:update --force
 
-# Clear Redis cache
+# Čišćenje Redis keša
 docker compose exec redis redis-cli FLUSHALL
 ```
 
-## Configuration
+## Konfiguracija
 
-The project configuration is managed through environment variables in the `.env` file:
+Konfiguracija projekta se upravlja kroz promenljive okruženja u `.env` fajlu:
 
-- `MYSQL_ROOT_PASSWORD`: Database root password
-- `MYSQL_DATABASE`: Database name
-- `MYSQL_USER`: Database user
-- `MYSQL_PASSWORD`: Database password
+- `MYSQL_ROOT_PASSWORD`: Root lozinka za bazu podataka
+- `MYSQL_DATABASE`: Ime baze podataka
+- `MYSQL_USER`: Korisnik baze podataka
+- `MYSQL_PASSWORD`: Lozinka za bazu podataka
 
-## Directory Structure
+## Struktura direktorijuma
 
-- `docker/` - Docker-related configuration files
-  - `nginx/conf.d/` - Nginx virtual host configurations
-  - `php/` - PHP configuration
-  - `scripts/` - Setup and utility scripts
+- `docker/` - Konfiguracioni fajlovi vezani za Docker
+  - `nginx/conf.d/` - Nginx konfiguracije virtualnih hostova
+  - `php/` - PHP konfiguracija
+  - `scripts/` - Skripte za podešavanje i uslužne skripte

--- a/README.docker.md
+++ b/README.docker.md
@@ -1,0 +1,90 @@
+# Docker Setup Instructions
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+- Git
+
+## Setup Steps
+
+1. Copy `.env.example` to `.env` and update the values:
+```bash
+cp .env.example .env
+# Edit .env with your desired values
+```
+
+2. Add these entries to your `/etc/hosts` file:
+```
+127.0.0.1 solidarity.local
+127.0.0.1 solidforms.local
+```
+
+2. Build and start the Docker containers:
+```bash
+docker compose up -d
+```
+
+The setup script will automatically:
+- Create the database
+- Install composer dependencies
+- Set up configuration files
+- Run database migrations
+- Create a test user
+
+## Services
+
+- Backend: http://solidarity.local
+- Frontend: http://solidforms.local
+- Adminer (Database Management): http://localhost:8080
+  - System: MySQL
+  - Server: mariadb
+  - Username: root
+  - Password: rootpass
+  - Database: solid
+- MailHog (Email Testing): http://localhost:8025
+- Redis: localhost:6379
+
+## Common Commands
+
+```bash
+# Start containers
+docker compose up -d
+
+# Stop containers
+docker compose down
+
+# View logs
+docker compose logs -f
+
+# Rebuild containers
+docker compose up -d --build
+
+# Access PHP container
+docker compose exec php bash
+
+# Run composer commands
+docker compose exec php composer install
+
+# Run database migrations
+docker compose exec php php bin/doctrine orm:schema-tool:update --force
+
+# Clear Redis cache
+docker compose exec redis redis-cli FLUSHALL
+```
+
+## Configuration
+
+The project configuration is managed through environment variables in the `.env` file:
+
+- `MYSQL_ROOT_PASSWORD`: Database root password
+- `MYSQL_DATABASE`: Database name
+- `MYSQL_USER`: Database user
+- `MYSQL_PASSWORD`: Database password
+
+## Directory Structure
+
+- `docker/` - Docker-related configuration files
+  - `nginx/conf.d/` - Nginx virtual host configurations
+  - `php/` - PHP configuration
+  - `scripts/` - Setup and utility scripts

--- a/README.md
+++ b/README.md
@@ -2,74 +2,102 @@
 
 Mreža solidarnosti je jednostavna web aplikacija koja omogućava korisnicima da se prijavljuju na istu putem formi ili da upravljaju podacima unutar dash-a.
 
-## Table of Contents
-- [Instalacija](#instalacija)
-- [Podešavanje baze](#podešavanje-baze-manuelna-instalacija)
-- [Upotreba](#upotreba)
+## Sadržaj
+- [IT Srbija - Mreža solidarnosti](#it-srbija---mreža-solidarnosti)
+  - [Sadržaj](#sadržaj)
+  - [Instalacija](#instalacija)
+    - [Docker instalacija (Preporučeno)](#docker-instalacija-preporučeno)
+    - [Vagrant instalacija](#vagrant-instalacija)
+  - [Podešavanje baze (manuelna instalacija)](#podešavanje-baze-manuelna-instalacija)
+  - [Upotreba](#upotreba)
+  - [Korisnički kredencijali](#korisnički-kredencijali)
+  - [Komande za bazu podataka](#komande-za-bazu-podataka)
+
 ## Instalacija
 
-Da biste instalirali APP na lokalu, pratite sledeće korake:
+### Docker instalacija (Preporučeno)
 
-1. Install vagrant - https://developer.hashicorp.com/vagrant/downloads
-2. Install virtualbox - https://www.virtualbox.org/wiki/Downloads
-3. From app root/config clone config-local.php-dist and constants.php.dist and remove .dist from file name
-4. Add entries to etc/hosts
+Za instalaciju pomoću Docker-a, pogledajte [README.docker.md](README.docker.md).
+
+### Vagrant instalacija
+
+Preduslovi:
+- Vagrant - https://developer.hashicorp.com/vagrant/downloads
+- VirtualBox - https://www.virtualbox.org/wiki/Downloads (nije potreban na Linux-u ako imate instaliran libvirt)
+
+Koraci:
+1. Iz app root/config klonirajte config-local.php-dist i constants.php.dist i uklonite .dist iz imena fajla
+2. Dodajte sledeće unose u etc/hosts fajl:
     ```bash
     192.168.25.43	solidarity.local
     192.168.25.43	solidforms.local
     ```
-5. From app root run (if stuck here try restarting guest system, usually windows)
+3. Iz korena aplikacije pokrenite (ako zapne, pokušajte restartovati guest sistem, obično Windows):
     ```bash
     vagrant up
     ```
-6. From app root run (manuelna instalacija)
+4. Iz korena aplikacije instalirajte zavisnosti:
     ```bash
     composer install
+    # ili ako composer nije instaliran globalno
     php composer.phar install
     ```
-   or update libraries
+   Za ažuriranje biblioteka:
     ```bash
     composer update
     php composer.phar update
     ```
 
+SSH pristup:
+- Komanda: `vagrant ssh`
+- Lozinka: `vagrant`
+
 ## Podešavanje baze (manuelna instalacija)
 
-Da biste podesili bazu za APP na lokalu, pratite sledeće korake:
+Da biste podesili bazu za aplikaciju na lokalu, pratite sledeće korake:
 
-1. Install MariaDB for example - https://mariadb.org/download/
-2. All details about the local database can be found here - app root/config/config-local.php
-3. Create APP database, open terminal and run
+1. Instalirajte MariaDB, na primer sa - https://mariadb.org/download/
+2. Svi detalji o lokalnoj bazi podataka mogu se naći u - app root/config/config-local.php
+3. Kreirajte bazu podataka, otvorite terminal i pokrenite:
     ```bash
     mysql -u root -p
     CREATE DATABASE solid;
-    ```
-4. To migrate database, run
-   ```bash
-    php bin/doctrine orm:schema-tool:update --complete --force --dump-sql
-    ```
-5. To validate database schema, run
-    ```bash
-    php bin/doctrine orm:validate-schema
-    ```
-6. To clear orm cache, run
-    ```bash
-    php bin/doctrine orm:clear-cache:metadata
-    php bin/doctrine orm:clear-cache:query
-    php bin/doctrine orm:clear-cache:result
     ```
 
 ## Upotreba
 
 Projekat sa formama će biti dostupan na `http://solidforms.local` a dash sistem na `http://solidarity.local`.
 
-1. To ssh into machine, from app root run (ssh password is vagrant)
+1. Za SSH pristup mašini, iz korena aplikacije pokrenite (SSH lozinka je vagrant):
     ```bash
     vagrant ssh
     ```
-2. To style and validate forms, navigate to app root/public/assets and run (node is required - https://nodejs.org/en/download)
+2. Za stilizovanje i validaciju formi, navigirajte do app root/public/assets i pokrenite (potreban je node - https://nodejs.org/en/download):
     ```bash
     npm install
     npm run build
     ```
-   Inside assets folder you will find scss files and js/main-default.js
+   Unutar assets foldera naći ćete scss fajlove i js/main-default.js
+
+## Korisnički kredencijali
+
+- Email: test@example.com
+- Lozinka: testtest
+
+## Komande za bazu podataka
+
+Za migraciju baze podataka:
+```bash
+php bin/doctrine orm:schema-tool:update --complete --force --dump-sql
+```
+
+Za validaciju šeme baze podataka:
+```bash
+php bin/doctrine orm:validate-schema
+```
+
+Za čišćenje ORM keša:
+```bash
+php bin/doctrine orm:clear-cache:metadata
+php bin/doctrine orm:clear-cache:query
+php bin/doctrine orm:clear-cache:result

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,12 +12,18 @@ Vagrant.configure(2) do |config|
   # boxes at https://atlas.hashicorp.com/search.
 
   config.vm.box = "bento/ubuntu-20.04"
+
+  # Override for libvirt provider (works with Linux machines without VirtualBox)
+  config.vm.provider :libvirt do |libvirt, override|
+    override.vm.box = "generic/ubuntu2004"
+  end
+
   config.vm.synced_folder "./", "/vagrant", :owner => "vagrant", :group => "www-data"
   config.vm.network "private_network", ip: "192.168.25.43"
 #   config.vm.boot_timeout = 120
 
   config.vm.provision :shell, path: "bootstrap.sh"
-  
+
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,90 @@
+version: "3.4"
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-file: "5"
+    max-size: "20m"
+
+services:
+  mariadb:
+    container_name: solidarity-mariadb
+    image: mariadb:10.11
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./db/data:/var/lib/mysql
+    ports:
+      - "127.0.0.1:3306:3306"
+    logging: *default-logging
+
+  redis:
+    container_name: solidarity-redis
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6379:6379"
+    logging: *default-logging
+
+  php:
+    container_name: solidarity-php
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - .:/var/www/html
+    depends_on:
+      - mariadb
+      - redis
+    logging: *default-logging
+
+  nginx:
+    container_name: solidarity-nginx
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - .:/var/www/html
+      - ./docker/nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      - php
+    logging: *default-logging
+
+  setup-project:
+    container_name: solidarity-setup-project
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - mariadb
+      - php
+    restart: "no"
+    env_file:
+      - .env
+    volumes:
+      - .:/var/www/html
+      - ./docker/scripts/docker-setup.sh:/docker-setup.sh
+    entrypoint: ["bash", "-c", "git config --global --add safe.directory /var/www/html && /docker-setup.sh"]
+    logging: *default-logging
+
+  mailhog:
+    container_name: solidarity-mailhog
+    image: mailhog/mailhog
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8025:8025"
+    logging: *default-logging
+
+  adminer:
+    container_name: solidarity-adminer
+    image: adminer
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    depends_on:
+      - mariadb
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 x-logging: &default-logging
   driver: "json-file"
   options:
@@ -71,14 +70,6 @@ services:
     entrypoint: ["bash", "-c", "git config --global --add safe.directory /var/www/html && /docker-setup.sh"]
     logging: *default-logging
 
-  mailhog:
-    container_name: solidarity-mailhog
-    image: mailhog/mailhog
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:8025:8025"
-    logging: *default-logging
-
   adminer:
     container_name: solidarity-adminer
     image: adminer
@@ -87,4 +78,14 @@ services:
       - "127.0.0.1:8080:8080"
     depends_on:
       - mariadb
+    logging: *default-logging
+
+  redis-insight:
+    container_name: solidarity-redis-insight
+    image: redis/redisinsight:2.68
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5540:5540"
+    depends_on:
+      - redis
     logging: *default-logging

--- a/docker/nginx/conf.d/solidarity.conf
+++ b/docker/nginx/conf.d/solidarity.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name solidarity.local;
+    root /var/www/html/public;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    client_max_body_size 16M;
+    client_body_buffer_size 2M;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param APPLICATION_ENV development;
+        fastcgi_param APPLICATION backend;
+        fastcgi_read_timeout 300;
+        fastcgi_buffer_size 32k;
+        fastcgi_buffers 16 16k;
+    }
+}

--- a/docker/nginx/conf.d/solidforms.conf
+++ b/docker/nginx/conf.d/solidforms.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name solidforms.local;
+    root /var/www/html/public;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    client_max_body_size 16M;
+    client_body_buffer_size 2M;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param APPLICATION_ENV development;
+        fastcgi_param APPLICATION frontend;
+        fastcgi_read_timeout 300;
+        fastcgi_buffer_size 32k;
+        fastcgi_buffers 16 16k;
+    }
+}

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,0 +1,25 @@
+[PHP]
+memory_limit = 256M
+max_execution_time = 300
+post_max_size = 100M
+upload_max_filesize = 100M
+max_input_vars = 3000
+
+[Date]
+date.timezone = Europe/Belgrade
+
+[opcache]
+opcache.enable = 1
+opcache.enable_cli = 1
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 8
+opcache.max_accelerated_files = 4000
+opcache.revalidate_freq = 0
+opcache.validate_timestamps = 1
+
+[xdebug]
+xdebug.mode = develop,debug
+xdebug.start_with_request = yes
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9003
+xdebug.log = /tmp/xdebug.log

--- a/docker/scripts/docker-setup.sh
+++ b/docker/scripts/docker-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+echo -e "\nWaiting for MySQL to be ready..."
+while ! mysql -h"mariadb" -P"3306" -u"root" -p"${MYSQL_ROOT_PASSWORD}" -e "SELECT 1;" >/dev/null 2>&1; do
+    echo -e "\nMySQL is not ready yet, waiting..."
+    sleep 1
+done
+
+echo -e "\nCreate MySQL database '${MYSQL_DATABASE}' (if not exists)"
+echo "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` COLLATE 'utf8_unicode_ci';" |
+    mysql -h"mariadb" -P"3306" -u"root" -p"${MYSQL_ROOT_PASSWORD}"
+
+echo "Set up MySQL user '${MYSQL_USER}'"
+echo "CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';" |
+    mysql -h"mariadb" -P"3306" -u"root" -p"${MYSQL_ROOT_PASSWORD}"
+echo "GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USER}'@'%';" |
+    mysql -h"mariadb" -P"3306" -u"root" -p"${MYSQL_ROOT_PASSWORD}"
+
+if [ ! -d /var/www/html/vendor ]; then
+    echo -e "\nInstalling composer dependencies"
+    composer install
+fi
+
+echo -e "\nSetting up configuration files"
+if [ ! -f /var/www/html/config/config-local.php ]; then
+    cp /var/www/html/config/config-local.php.dist /var/www/html/config/config-local.php
+    sed -i "s/'host' => 'localhost'/'host' => 'mariadb'/g" /var/www/html/config/config-local.php
+    sed -i "s/'user' => 'root'/'user' => '${MYSQL_USER}'/g" /var/www/html/config/config-local.php
+    sed -i "s/'pass' => 'rootpass'/'pass' => '${MYSQL_PASSWORD}'/g" /var/www/html/config/config-local.php
+    sed -i "s/'127.0.0.1' => 6379/'redis' => 6379/g" /var/www/html/config/config-local.php
+fi
+echo -e "\nChecking for constants.php file"
+if [ ! -f /var/www/html/config/constants.php ]; then
+    echo -e "constants.php not found, copying from constants.php.dist"
+    cp /var/www/html/config/constants.php.dist /var/www/html/config/constants.php
+    echo -e "constants.php created successfully"
+else
+    echo -e "constants.php already exists"
+fi
+
+echo -e "\nCreating necessary directories"
+mkdir -p /var/www/html/data/logs/$(date +"%Y-%m")
+chmod -R 777 /var/www/html/data
+
+echo -e "\nRunning database migrations"
+php /var/www/html/bin/doctrine orm:schema-tool:update --force --dump-sql
+
+echo -e "\nCreating test user"
+mysql -h"mariadb" -P"3306" -u"root" -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DATABASE}" <<EOF
+INSERT INTO user (firstName, lastName, email, password, role, isActive, displayName, id)
+SELECT 'test', 'test', 'test@example.com', '\$2y\$10\$GGArVO/7.xPDg6D5Kl6GHeELUg2Dnod68ynkFaZ7R2Vfx/K1oZ96O', '1', '1', 'test', '3'
+WHERE NOT EXISTS (SELECT 1 FROM user WHERE id = '3');
+EOF
+
+echo -e "\nSetup completed!"
+

--- a/public/index.php
+++ b/public/index.php
@@ -6,7 +6,7 @@ use Skeletor\Core\App\WebSkeletor;
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-include("../config/constants.php");
+include(__DIR__ . "/../config/constants.php");
 include(APP_PATH . "/vendor/autoload.php");
 $path = getenv('APPLICATION');
 if (getenv('APPLICATION_ENV') !== 'production') {


### PR DESCRIPTION
Pozdrav, evo Docker Compose dev setupa. Testirao sam i radi.

Docker se oslanja na .env file, to je negde standard za secrets, mozda ne bi bilo zgoreg da se doda dotenv php lib i da config php files ucita variable iz .env fajla.

Jos jedan note: razlika u odnosu na vagrant setup je i local ip u `/etc/hosts/`

```bash
❯ tail -2 /etc/hosts
127.0.0.1 solidarity.local
127.0.0.1 solidforms.local
```

Ako imate neke sugestije javite :)